### PR TITLE
Fix broken README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Finally, [Cards Against Humanity](https://cardsagainsthumanity.com/) as plain te
 
 ## FAQ
 
-**How many cards are there?** [Check the website](https://crhallberg/cah).
+**How many cards are there?** [Check the website](https://crhallberg.com/cah).
 
 **What font is CAH?** Cards Against Humanity cards are in [Helvetica® Neue](https://www.myfonts.com/fonts/linotype/neue-helvetica/). It's not free. I use [Inter Medium](https://rsms.me/inter/).
 


### PR DESCRIPTION
There is a link in the README which led to the website, but was brokenly linked without the `.com` of the domain. This commit fixes that.